### PR TITLE
Make compatible with WorldPainter 2.14.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.pepsoft.worldpainter</groupId>
         <artifactId>PluginParent</artifactId>
-        <version>1.5.0</version>
+        <version>1.6.0</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.pepsoft.worldpainter</groupId>
         <artifactId>PluginParent</artifactId>
-        <version>1.6.0</version>
+        <version>1.7.0</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,11 @@
     <artifactId>worldpainterplugin</artifactId>
     <version>1.3.0</version>
 
-    <!--<parent>
+    <parent>
         <groupId>org.pepsoft.worldpainter</groupId>
         <artifactId>PluginParent</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
-    </parent>-->
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -27,50 +27,6 @@
     </repositories>
 
     <dependencies>
-        <dependency>
-            <groupId>org.pepsoft.worldpainter</groupId>
-            <artifactId>WPGUI</artifactId>
-            <version>2.8.8</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.pepsoft.worldpainter</groupId>
-                    <artifactId>WPDynmapPreviewer</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.sourceforge</groupId>
-                    <artifactId>jpen</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.jidesoft</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.netbeans.swing</groupId>
-                    <artifactId>laf-dark</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.nativelibs4java</groupId>
-                    <artifactId>bridj</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>jcl-over-slf4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>jul-to-slf4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-to-slf4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>io.github.opencubicchunks</groupId>
             <artifactId>regionlib</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.pepsoft.worldpainter</groupId>
         <artifactId>PluginParent</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.5.0</version>
     </parent>
 
     <properties>

--- a/src/main/java/io/github/opencubicchunks/worldpainterplugin/CubicChunkStore.java
+++ b/src/main/java/io/github/opencubicchunks/worldpainterplugin/CubicChunkStore.java
@@ -127,8 +127,12 @@ public class CubicChunkStore implements ChunkStore {
         for (MinecraftCoords pos : getChunkOrder()) {
             Chunk16Virtual chunk = loadChunk(pos.x, pos.z, editMode);
             if (chunk != null) {
-                if (!chunkVisitor.visitChunk(chunk)) {
-                    return false;
+                try {
+                    if (!chunkVisitor.visitChunk(chunk)) {
+                        return false;
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
                 }
             }
         }

--- a/src/main/java/io/github/opencubicchunks/worldpainterplugin/CubicChunksMapRecognizer.java
+++ b/src/main/java/io/github/opencubicchunks/worldpainterplugin/CubicChunksMapRecognizer.java
@@ -43,6 +43,6 @@ public class CubicChunksMapRecognizer implements MapRecognizer {
             return ICON;
         }
 
-        private static final Icon ICON = IconUtils.scaleIcon(IconUtils.loadScaledIcon("io/github/opencubicchunks/worldpainterplugin/logo.png"), 16);
+        static final Icon ICON = IconUtils.scaleIcon(IconUtils.loadScaledIcon(CubicChunksMapRecognizer.class.getClassLoader(), "io/github/opencubicchunks/worldpainterplugin/logo.png"), 16);
     }
 }

--- a/src/main/java/io/github/opencubicchunks/worldpainterplugin/CubicChunksPlatformProvider.java
+++ b/src/main/java/io/github/opencubicchunks/worldpainterplugin/CubicChunksPlatformProvider.java
@@ -22,6 +22,7 @@ import org.pepsoft.worldpainter.exporting.ExportSettings;
 import org.pepsoft.worldpainter.exporting.ExportSettingsEditor;
 import org.pepsoft.worldpainter.exporting.PostProcessor;
 import org.pepsoft.worldpainter.exporting.WorldExporter;
+import org.pepsoft.worldpainter.exporting.WorldExportSettings;
 import org.pepsoft.worldpainter.importing.JavaMapImporter;
 import org.pepsoft.worldpainter.importing.MapImporter;
 import org.pepsoft.worldpainter.mapexplorer.MapExplorerSupport;
@@ -155,12 +156,12 @@ public class CubicChunksPlatformProvider extends AbstractPlugin implements Block
     }
 
     @Override
-    public WorldExporter getExporter(World2 world) {
+    public WorldExporter getExporter(World2 world, WorldExportSettings exportSettings) {
         Platform platform = world.getPlatform();
         if (!platform.equals(CUBICCHUNKS)) {
             throw new IllegalArgumentException("Platform " + platform + " not supported");
         }
-        return new CubicChunksWorldExporter(world);
+        return new CubicChunksWorldExporter(world, exportSettings);
     }
 
     @Override

--- a/src/main/java/io/github/opencubicchunks/worldpainterplugin/CubicChunksPlatformProvider.java
+++ b/src/main/java/io/github/opencubicchunks/worldpainterplugin/CubicChunksPlatformProvider.java
@@ -179,13 +179,13 @@ public class CubicChunksPlatformProvider extends AbstractPlugin implements Block
     }
 
     @Override
-    public ExportSettings getDefaultExportSettings() {
+    public ExportSettings getDefaultExportSettings(Platform platform) {
         return new JavaExportSettings();
     }
 
     @Override
-    public ExportSettingsEditor getExportSettingsEditor() {
-        return new JavaExportSettingsEditor();
+    public ExportSettingsEditor getExportSettingsEditor(Platform platform) {
+        return new JavaExportSettingsEditor(platform);
     }
 
     @Override
@@ -204,7 +204,7 @@ public class CubicChunksPlatformProvider extends AbstractPlugin implements Block
 
     @Override
     public MapImporter getImporter(File dir, TileFactory tileFactory, Set<MinecraftCoords> chunksToSkip, MapImporter.ReadOnlyOption readOnlyOption, Set<Integer> dimensionsToImport) {
-        return new JavaMapImporter(CUBICCHUNKS, tileFactory, new File(dir, "level.dat"), false, chunksToSkip, readOnlyOption, dimensionsToImport);
+        return new JavaMapImporter(CUBICCHUNKS, tileFactory, new File(dir, "level.dat"), chunksToSkip, readOnlyOption, dimensionsToImport);
     }
 
     // MapExplorerSupport

--- a/src/main/java/io/github/opencubicchunks/worldpainterplugin/CubicChunksWorldExporter.java
+++ b/src/main/java/io/github/opencubicchunks/worldpainterplugin/CubicChunksWorldExporter.java
@@ -8,6 +8,7 @@ import org.pepsoft.worldpainter.Dimension;
 import org.pepsoft.worldpainter.Dimension.Anchor;
 import org.pepsoft.worldpainter.exporting.AbstractWorldExporter;
 import org.pepsoft.worldpainter.exporting.JavaWorldExporter;
+import org.pepsoft.worldpainter.exporting.WorldExportSettings;
 import org.pepsoft.worldpainter.history.HistoryEntry;
 import org.pepsoft.worldpainter.util.FileInUseException;
 import org.pepsoft.worldpainter.vo.EventVO;
@@ -26,8 +27,8 @@ import static org.pepsoft.worldpainter.Dimension.Anchor.*;
 import static org.pepsoft.worldpainter.Dimension.Role.DETAIL;
 
 public class CubicChunksWorldExporter extends AbstractWorldExporter {
-    public CubicChunksWorldExporter(World2 world) {
-        super(world, CubicChunksPlatformProvider.CUBICCHUNKS);
+    public CubicChunksWorldExporter(World2 world, WorldExportSettings worldExportSettings) {
+        super(world, worldExportSettings, CubicChunksPlatformProvider.CUBICCHUNKS);
         if ((!world.getPlatform().equals(CubicChunksPlatformProvider.CUBICCHUNKS))) {
             throw new IllegalArgumentException("Unsupported platform " + world.getPlatform());
         }
@@ -36,8 +37,8 @@ public class CubicChunksWorldExporter extends AbstractWorldExporter {
     @Override
     public Map<Integer, ChunkFactory.Stats> export(File baseDir, String name, File backupDir, ProgressReceiver progressReceiver) throws IOException, ProgressReceiver.OperationCancelled {
         // Sanity checks
-        final Set<Point> selectedTiles = world.getTilesToExport();
-        final Set<Integer> selectedDimensions = world.getDimensionsToExport();
+        final Set<Point> selectedTiles = worldExportSettings.getTilesToExport();
+        final Set<Integer> selectedDimensions = worldExportSettings.getDimensionsToExport();
         if ((selectedTiles == null) && (selectedDimensions != null)) {
             throw new IllegalArgumentException("Exporting a subset of dimensions not supported");
         }
@@ -240,8 +241,8 @@ public class CubicChunksWorldExporter extends AbstractWorldExporter {
 
         // Calculate total size of dimension
         Set<Point> regions = new HashSet<>(), exportedRegions = new HashSet<>();
-        if (world.getTilesToExport() != null) {
-            for (Point tile : world.getTilesToExport()) {
+        if (worldExportSettings.getTilesToExport() != null) {
+            for (Point tile : worldExportSettings.getTilesToExport()) {
                 regions.add(new Point(tile.x >> 2, tile.y >> 2));
             }
         } else {

--- a/src/main/java/io/github/opencubicchunks/worldpainterplugin/CubicChunksWorldExporter.java
+++ b/src/main/java/io/github/opencubicchunks/worldpainterplugin/CubicChunksWorldExporter.java
@@ -33,6 +33,8 @@ public class CubicChunksWorldExporter extends AbstractWorldExporter {
     @Override
     public Map<Integer, ChunkFactory.Stats> export(File baseDir, String name, File backupDir, ProgressReceiver progressReceiver) throws IOException, ProgressReceiver.OperationCancelled {
         // Sanity checks
+        final Set<Point> selectedTiles = world.getTilesToExport();
+        final Set<Integer> selectedDimensions = world.getDimensionsToExport();
         if ((selectedTiles == null) && (selectedDimensions != null)) {
             throw new IllegalArgumentException("Exporting a subset of dimensions not supported");
         }
@@ -238,8 +240,8 @@ public class CubicChunksWorldExporter extends AbstractWorldExporter {
 
         // Calculate total size of dimension
         Set<Point> regions = new HashSet<>(), exportedRegions = new HashSet<>();
-        if (selectedTiles != null) {
-            for (Point tile : selectedTiles) {
+        if (world.getTilesToExport() != null) {
+            for (Point tile : world.getTilesToExport()) {
                 regions.add(new Point(tile.x >> 2, tile.y >> 2));
             }
         } else {


### PR DESCRIPTION
Here are the most minimal changes to make your plugin fully compatible with the upcoming release of WorldPainter (most likely will be 2.9.0). You will most likely want to make further changes (the `CubicChunksMapRecognizer` class is now obsolete, for example, and I haven't changed the version number, etc.), but I wanted to keep my interference minimal.

The `SNAPSHOT` dependency can be found in https://oss.sonatype.org/content/repositories/snapshots/. I'll let you know when I release WorldPainter so you can update to the production dependency. Or you can get these changes from GitHub; they are on `master`.

Note that the existing plugin should also keep working, but not optimally.